### PR TITLE
support curl read timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV SLACK_USERNAME "example"
 ENV SLACK_NOTIFICATION_TEXT "This is an example text"
 ENV SLACK_NOTIFICATION_ICON ":ghost:"
 ENV SLACK_NOTIFICATION_WEBHOOK_URL "http://example.org"
+ENV CURL_MAX_TIMEOUT 30
 
 RUN apk add --update curl && \
     rm -rf /var/cache/apk/*

--- a/entry-point.sh
+++ b/entry-point.sh
@@ -8,10 +8,11 @@ username=$SLACK_USERNAME
 text=$SLACK_NOTIFICATION_TEXT
 icon=$SLACK_NOTIFICATION_ICON
 webhook_url=$SLACK_NOTIFICATION_WEBHOOK_URL
+curl_max_timeout=$CURL_MAX_TIMEOUT
 
 while :
 do
-  status=`curl -s -o /dev/null -w "%{http_code}" $status_url`
+  status=`curl -m $curl_max_timeout -s -o /dev/null -w "%{http_code}" $status_url`
   if [ $status -eq 200 ]; then
     echo "Application works."
     sleep $status_timeout


### PR DESCRIPTION
Sometimes it's important to get a response within a specific time (e.g. 20 sec) otherwise it should alert. Added a new variable and updated the curl command to support the timeout. 